### PR TITLE
"Community driven projects" page

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -28,4 +28,4 @@
 ## How do I contribute?
 
 * [Contributing](CONTRIBUTING.md)
-* [Community](community/community-projects.md)
+* [Community Driven Projects](community/community-projects.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -28,3 +28,4 @@
 ## How do I contribute?
 
 * [Contributing](CONTRIBUTING.md)
+* [Community](community/community-projects.md)

--- a/community/community-projects.md
+++ b/community/community-projects.md
@@ -1,6 +1,6 @@
 # Community Driven Projects
 
-We want to shout out some community driven projects around the Kick Dev ecosystem.
+Highlighting standout community-driven projects within the Kick Dev ecosystem.
 
 > **_NOTE_**: Disclaimer
 > 
@@ -10,7 +10,7 @@ We want to shout out some community driven projects around the Kick Dev ecosyste
 
 ## Libraries
 
-Community built libraries to help you interact with the API.
+Explore community-built SDKs designed to simplify and enhance your interaction with the API.
 
 ### JS / Typescript
 
@@ -18,7 +18,7 @@ Community built libraries to help you interact with the API.
 
 ## Documentation
 
-Community created documentation on how to interact with the API.
+Community-created guides and resources to help you interact with the API efficiently.
 
 ### OAuth Flow
 

--- a/community/community-projects.md
+++ b/community/community-projects.md
@@ -1,0 +1,25 @@
+# Community Driven Projects
+
+We want to shout out some community driven projects around the Kick Dev ecosystem.
+
+> **_NOTE_**: Disclaimer
+> 
+> We do not own, operate, or take responsibility for any of the links or websites provided. These links are shared for informational purposes only, and we do not guarantee the accuracy, reliability, or security of the content they contain. Accessing these external websites is at your own risk, and we are not liable for any issues, damages, or consequences that may arise from their use.
+> 
+> Additionally, any examples, libraries, or resources mentioned should be independently verified before use. Please conduct your own research to ensure their suitability and security for your specific needs.
+
+## Libraries
+
+Community built libraries to help you interact with the API.
+
+### JS / Typescript
+
+- [NodeJS Client for Kick.com](https://www.npmjs.com/package/@botk4cp3r/kick.js)
+
+## Documentation
+
+Community created documentation on how to interact with the API.
+
+### OAuth Flow
+
+- [Basic Node OAuth Flow example](https://gist.github.com/ACPixel/bd71dc716126153e04e41700e8a8820e)


### PR DESCRIPTION
Add a page to show off community driven libraries and documentation that help other developers interact with Kick Dev.