### PR TITLE
Kick-Event-Subscription-Id header to Webhook events

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,6 @@ Our goals during this phase is to get feedback and iterate quickly. We want to c
 
 | Date       | Description                                         |
 | ---------- | --------------------------------------------------- |
-| 21/02/2025 | Kick-Event-Subscription-Id Webhook header           |
+| 24/02/2025 | Kick-Event-Subscription-Id Webhook header           |
 | 20/02/2025 | Community Contributors page                         |
 | 19/02/2025 | Kick Dev API released                               |

--- a/README.md
+++ b/README.md
@@ -77,3 +77,11 @@ Our goals during this phase is to get feedback and iterate quickly. We want to c
 | Chat bot badge                      | 🟡               | New                 |
 | Granular scope OAuth consent screen | 🟡               | New                 |
 | GET /public-key                     | 🟡               | New                 |
+
+## Changelog
+
+| Date       | Description                                         |
+| ---------- | --------------------------------------------------- |
+| 21/02/2025 | Kick-Event-Subscription-Id Webhook header           |
+| 20/02/2025 | Community Contributors page                         |
+| 19/02/2025 | Kick Dev API released                               |

--- a/events/webhook-security.md
+++ b/events/webhook-security.md
@@ -8,13 +8,14 @@ App Access Tokens and User Access Tokens can access this.
 
 ## Headers
 
-| Header                         | Type                 | Short Description                      |
-|--------------------------------|----------------------|----------------------------------------|
-| `Kick-Event-Message-Id`        | ULID                 | Unique message ID, idempotent key      |
-| `Kick-Event-Signature`         | Base64 Encode String | Signature to verify the sender         |
-| `Kick-Event-Message-Timestamp` | RFC3339 Date-time    | Timestamp of when the message was sent |
-| `Kick-Event-Type`              | string               | e.g. `channel:write`                   |
-| `Kick-Event-Version`           | string               | e.g. `1`                               |
+| Header                         | Type                 | Short Description                       |
+|--------------------------------|----------------------|-----------------------------------------|
+| `Kick-Event-Message-Id`        | ULID                 | Unique message ID, idempotent key       |
+| `Kick-Event-Subscription-Id`   | ULID                 | Subscription ID associated with event   |
+| `Kick-Event-Signature`         | Base64 Encode String | Signature to verify the sender          |
+| `Kick-Event-Message-Timestamp` | RFC3339 Date-time    | Timestamp of when the message was sent  |
+| `Kick-Event-Type`              | string               | e.g. `channel:write`                    |
+| `Kick-Event-Version`           | string               | e.g. `1`                                |
 
 ## Webhook Sender Validation
 

--- a/getting-started/generating-tokens-oauth2-flow.md
+++ b/getting-started/generating-tokens-oauth2-flow.md
@@ -93,6 +93,11 @@ https://yourapp.com/callback?code=<code>&state=random-state
 
 Exchanges the code for a valid access token and a refresh token that can be used to make authorised requests to Kick's API.
 
+**Headers**
+| Name          | Required | Type    | Value                             |
+| ------------- | -------- | ------- | --------------------------------- |
+| Content-Type  | true     | string  | application/x-www-form-urlencoded |
+
 **Body**
 
 | Name            | Required | Type   | Description                                      |
@@ -133,14 +138,17 @@ Exchanges the code for a valid access token and a refresh token that can be used
 <pre><code>POST
 https://id.kick.com/oauth/token
 
-Request Form Body:
+Headers: 
+Content-Type: application/x-www-form-urlencoded
+
+Body:
 {
     grant_type=authorization_code
     client_id=&#x3C;client_id>
     client_secret=&#x3C;client_secret>
     redirect_uri=&#x3C;redirect_uri>
-<strong>    code_verifier=&#x3C;code_verifier>
-</strong>    code=&#x3C;CODE>
+    code_verifier=&#x3C;code_verifier>
+    code=&#x3C;CODE>
 }
 </code></pre>
 
@@ -161,6 +169,11 @@ Request Form Body:
 <mark style="color:green;">`POST`</mark> `/oauth/token`
 
 Pass in refresh token and refresh both access and refresh codes.
+
+**Headers**
+| Name          | Required | Type    | Value                             |
+| ------------- | -------- | ------- | --------------------------------- |
+| Content-Type  | true     | string  | application/x-www-form-urlencoded |
 
 **Body**
 
@@ -201,7 +214,10 @@ Pass in refresh token and refresh both access and refresh codes.
 POST
 https://id.kick.com/oauth/token
 
-Request Form Body:
+Headers: 
+Content-Type: application/x-www-form-urlencoded
+
+Body:
 {
     grant_type=refresh_token
     client_id=<client_id>

--- a/getting-started/generating-tokens-oauth2-flow.md
+++ b/getting-started/generating-tokens-oauth2-flow.md
@@ -244,6 +244,11 @@ Body:
 
 Pass in a token to revoke access to that token.
 
+**Headers**
+| Name          | Required | Type    | Value                             |
+| ------------- | -------- | ------- | --------------------------------- |
+| Content-Type  | true     | string  | application/x-www-form-urlencoded |
+
 **Query**
 
 | Name              | Required | Type   | Description                       |
@@ -272,6 +277,9 @@ OK
 ```
 POST
 https://id.kick.com/oauth/revoke?token=<your_token>&token_hint_type=<token_type>
+
+Headers: 
+Content-Type: application/x-www-form-urlencoded
 ```
 
 #### Example Response


### PR DESCRIPTION
Adding `Kick-Event-Subscription-Id` to the Webhook headers.

The updated OpenAPI spec will be released at the same time to fix up /public/v1/events/subscriptions documentation status codes.

Added additional information to OAuth headers for /oauth/token.

This will be merged once this change is live.