### PR TITLE
Add Go SDK in community documentation

### DIFF
--- a/community/community-projects.md
+++ b/community/community-projects.md
@@ -25,6 +25,10 @@ Explore community-built SDKs designed to simplify and enhance your interaction w
 
 - [KickLib - .NET Client](https://github.com/Bukk94/KickLib)
 
+### Golang
+
+- [Go Client for Kick.com](https://github.com/Scorfly/gokick)
+
 ## Documentation
 
 Community-created guides and resources to help you interact with the API efficiently.


### PR DESCRIPTION
🛠️ This is a Go SDK covering 100% of the KICK public API.

In the repos there a also a script to test the Auth in Golang

 - https://github.com/Scorfly/gokick/tree/main/scripts

Should I also add this script in the `### OAuth Flow` section ?

I could also add to the documentation an example of Auth in Python:
 - https://github.com/blazejszhxk/kick-auth/

Should I add it in the `### OAuth Flow` section ?