### PR TITLE
chore: allow updating app name

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Check out our Public Roadmap [here](https://github.com/orgs/KickEngineering/proj
 
 | Date       | Description                                         |
 | ---------- | --------------------------------------------------- |
+| 05/03/2025 | Allow editing app names on developer table          |
+| 03/03/2025 | Added Livestream Information on Channels Endpoint   |
 | 24/02/2025 | Kick-Event-Subscription-Id Webhook header           |
 | 20/02/2025 | Community Contributors page                         |
 | 19/02/2025 | Kick Dev API released                               |

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Check out our Public Roadmap [here](https://github.com/orgs/KickEngineering/proj
 
 | Date       | Description                                         |
 | ---------- | --------------------------------------------------- |
-| 05/03/2025 | Allow editing app names on developer table          |
+| 05/03/2025 | Allow editing app names on developer tab            |
 | 03/03/2025 | Added Livestream Information on Channels Endpoint   |
 | 24/02/2025 | Kick-Event-Subscription-Id Webhook header           |
 | 20/02/2025 | Community Contributors page                         |


### PR DESCRIPTION
Users can now update the app's name on the developer tab. 