### PR TITLE
Update OpenAPI references for event subscriptions

### DIFF
--- a/events/subscribe-to-events.md
+++ b/events/subscribe-to-events.md
@@ -4,16 +4,16 @@ icon: left-long-to-line
 
 # Subscribe to Events
 
-{% openapi src="https://api.kick.com/swagger/v1/doc.json" path="/events/subscriptions" method="get" %}
-[https://api.kick.com/swagger/v1/doc.json](https://api.kick.com/swagger/v1/doc.json)
-{% endopenapi %}
+{% openapi-operation spec="kick-dev-api" path="/public/v1/events/subscriptions" method="get" %}
+[OpenAPI kick-dev-api](https://api.kick.com/swagger/doc.yaml)
+{% endopenapi-operation %}
 
 
 Note: The `event` field corresponds to the appropriate Event name defined in the [Events table](https://docs.kick.com/events/event-types#events)
-{% openapi src="https://api.kick.com/swagger/v1/doc.json" path="/events/subscriptions" method="post" %}
-[https://api.kick.com/swagger/v1/doc.json](https://api.kick.com/swagger/v1/doc.json)
-{% endopenapi %}
+{% openapi-operation spec="kick-dev-api" path="/public/v1/events/subscriptions" method="post" %}
+[OpenAPI kick-dev-api](https://api.kick.com/swagger/doc.yaml)
+{% endopenapi-operation %}
 
-{% openapi src="https://api.kick.com/swagger/v1/doc.json" path="/events/subscriptions" method="delete" %}
-[https://api.kick.com/swagger/v1/doc.json](https://api.kick.com/swagger/v1/doc.json)
-{% endopenapi %}
+{% openapi-operation spec="kick-dev-api" path="/public/v1/events/subscriptions" method="delete" %}
+[OpenAPI kick-dev-api](https://api.kick.com/swagger/doc.yaml)
+{% endopenapi-operation %}


### PR DESCRIPTION
This updates the subscribe to events page to match openapi spec usage for gitbook to match the other reference pages. Currently the page is blank besides the note, so this should add back the endpoints to be used.

Assuming you guys do github -> gitbook sync, otherwise you can just fix it in gitbook and close this.

Thanks