### PR TITLE
chore: add kick.js package to community projects

### DIFF
--- a/community/community-projects.md
+++ b/community/community-projects.md
@@ -20,6 +20,7 @@ Explore community-built SDKs designed to simplify and enhance your interaction w
 
 ### JS / Typescript
 
+- [kick.js - Client for Kick.com](https://www.npmjs.com/package/@phxgg/kick.js)
 - [NodeJS Client for Kick.com](https://www.npmjs.com/package/@botk4cp3r/kick.js)
 - [NodeJS OAuth for Kick.com](https://www.npmjs.com/package/kick-auth)
 - [Kient - Typescript Client](https://github.com/zSoulweaver/kient)


### PR DESCRIPTION
Adds my [@phxgg/kick.js](https://www.npmjs.com/package/@phxgg/kick.js) package in the community driven projects page.

Full typescript support and full coverage of of Kick's API.

Well documented, and includes web app examples.