### PR TITLE
docs(oauth): fix broken 127.0.0.1 workaround URL and invalid JSON in token examples

### DIFF
--- a/getting-started/generating-tokens-oauth2-flow.md
+++ b/getting-started/generating-tokens-oauth2-flow.md
@@ -194,7 +194,7 @@ Uses a client\_id and client\_secret to generate an app access token which can b
 {
   "access_token": "",
   "token_type": "",
-  "expires_in": "",
+  "expires_in": ""
 }
 ```
 {% endtab %}
@@ -231,7 +231,7 @@ Body:
 {
   "access_token": "",
   "expires_in": "",
-  "token_type": "",
+  "token_type": ""
 }
 ```
 
@@ -413,7 +413,7 @@ GET
 https://id.kick.com/oauth/authorize?
     response_type=code&
     client_id=<your_client_id>&
-    redirect=127.0.0.1
+    redirect=127.0.0.1&
     redirect_uri=<http://127.0.0.1/callback>&
     scope=<scopes>&
     code_challenge=<code_challenge>&


### PR DESCRIPTION
### What
Three small correctness fixes in `getting-started/generating-tokens-oauth2-flow.md`:

1. **`127.0.0.1` workaround example** - added the missing `&` after the sacrificial `redirect=127.0.0.1` parameter. As written, `redirect=127.0.0.1` runs straight into `redirect_uri=...`, so the query string parses as a single `redirect` parameter and `redirect_uri` is dropped entirely - copying the documented workaround produces a request with no `redirect_uri`, and authorization fails.
2 & 3. **App Access Token examples** - removed trailing commas before the closing brace in two JSON snippets (the `200` response tab and the Example Response) so they are valid JSON.

### Verification
- Parsing the corrected authorize URL now yields `redirect_uri=http://127.0.0.1/callback` as its own parameter (previously absent).
- Both App Access Token JSON examples now parse as valid JSON.

Net change: one `&` added, two commas removed.